### PR TITLE
Feature/flux capacitor

### DIFF
--- a/lib/git_time_machine/flux_capacitor.rb
+++ b/lib/git_time_machine/flux_capacitor.rb
@@ -1,0 +1,32 @@
+module GitTimeMachine
+  class FluxCapacitor
+    class NoFuelError < RuntimeError; end
+
+    def initialize
+      @plutonium = nil
+    end
+
+    def setup
+      @plutonium = :weapons_grade
+    end
+
+    def capacitate!
+      raise NoFuelError unless plutonium_present?
+
+      @flux = :capacitated
+    end
+
+    def capacitated?
+      flux == :capacitated
+    end
+
+    private
+
+    attr_reader :flux
+    attr_reader :plutonium
+
+    def plutonium_present?
+      !plutonium.nil?
+    end
+  end
+end

--- a/lib/git_time_machine/time_machine.rb
+++ b/lib/git_time_machine/time_machine.rb
@@ -1,9 +1,14 @@
+require 'git_time_machine/flux_capacitor'
+
 module GitTimeMachine
   class TimeMachine
     def initialize
+      @flux_capacitor = GitTimeMachine::FluxCapacitor.new
     end
 
     def get_ready!
+      flux_capacitor.setup
+      flux_capacitor.capacitate!
     end
 
     def back_to(time_string)
@@ -11,11 +16,15 @@ module GitTimeMachine
     end
 
     def flux_capacitated?
-      false
+      flux_capacitor.capacitated?
     end
 
     def velocity
       0
     end
+
+    private
+
+    attr_reader :flux_capacitor
   end
 end


### PR DESCRIPTION
As noted in https://github.com/knightstick/git_time_machine/issues/3, I think we need to capacitate our flux before being able to travel through time.

This PR implements a new Flux Capacitor class, and we initialize, set up and capicitate it whilst setting up our Time Machine.

Must be nearly there now...

Pictured: Flux capacitor
![flux-capacitor](https://cloud.githubusercontent.com/assets/5941208/19642167/cacf232c-9a2f-11e6-8e03-0b59cf576aff.jpeg)
