### PR TITLE
Hotfix/rubygems

### DIFF
--- a/git_time_machine.gemspec
+++ b/git_time_machine.gemspec
@@ -16,18 +16,18 @@ Gem::Specification.new do |spec|
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
   # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
+  #if spec.respond_to?(:metadata)
+    #spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+  #else
+    #raise "RubyGems 2.0 or newer is required to protect against " \
+      #"public gem pushes."
+  #end
 
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end
-  spec.bindir        = "exe"
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir        = "bin"
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.13"

--- a/lib/git_time_machine/version.rb
+++ b/lib/git_time_machine/version.rb
@@ -1,3 +1,3 @@
 module GitTimeMachine
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
Allow git_time_machine as an executable
