### PR TITLE
Hotfix/modules

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    git_time_machine (1.0.0)
+    git_time_machine (1.0.2)
 
 GEM
   remote: https://rubygems.org/

--- a/lib/git_time_machine/time_machine.rb
+++ b/lib/git_time_machine/time_machine.rb
@@ -3,7 +3,7 @@ require 'git_time_machine/flux_capacitor'
 
 module GitTimeMachine
   class TimeMachine
-    extend Forwardable
+    extend ::Forwardable
 
     def_delegators :@delorean, :velocity
 

--- a/lib/git_time_machine/version.rb
+++ b/lib/git_time_machine/version.rb
@@ -1,3 +1,3 @@
 module GitTimeMachine
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end


### PR DESCRIPTION
When installing from RubyGems, the Forwardable module was being looked for within the TimeMachine class, so, I added the `::` to escape it.
